### PR TITLE
Optimize dockerfile

### DIFF
--- a/ziti.Dockerfile
+++ b/ziti.Dockerfile
@@ -1,29 +1,44 @@
-FROM golang
-ENV GO111MODULE=on
-#ENV APP_USER=appuser
-#ENV APP_GROUP=appgroup
-#ENV APP_HOME=/app
-#ARG GROUP_ID=1000
-#ARG USER_ID=1000
-#RUN groupadd --gid $GROUP_ID $APP_GROUP && useradd -m -l --uid $USER_ID --gid $GROUP_ID $APP_USER
-#RUN mkdir -p $APP_HOME
-#RUN chown -R $APP_USER:$APP_GROUP $APP_HOME
-#RUN chmod -R 0777 $APP_HOME
-#USER $APP_USER
 ARG ARCH="amd64"
 ARG OS="linux"
+
+FROM golang as build
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+RUN apt-get install -y bzip2 nodejs
+ADD . /build
+WORKDIR /build
+# openziti:foundation requires cgo.
+# enable cgo by hijacking the PROMU_BINARIES variable to pass `--cgo` to promu
+RUN rm -rf web/ui/node_modules
+RUN make build PROMU_BINARIES=--cgo
+
+
+###
+# The final stage is a slightly modified version of
+#   https://github.com/openziti-incubator/prometheus/blob/main/Dockerfile
+#
+
+FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
+LABEL maintainer="NetFoundry - The Prometheus Zitifiers <adv-dev@netfoundry.io>"
+
+ARG ARCH="amd64"
+ARG OS="linux"
+COPY --from=build /build/prometheus                             /bin/prometheus
+COPY --from=build /build/promtool                               /bin/promtool
+COPY --from=build /build/documentation/examples/prometheus.yml  /etc/prometheus/prometheus.yml
+COPY --from=build /build/console_libraries/                     /usr/share/prometheus/console_libraries/
+COPY --from=build /build/consoles/                              /usr/share/prometheus/consoles/
+COPY --from=build /build/LICENSE                                /LICENSE
+COPY --from=build /build/NOTICE                                 /NOTICE
+COPY --from=build /build/npm_licenses.tar.bz2                   /npm_licenses.tar.bz2
+
 WORKDIR /prometheus
-ADD . /prometheus
-RUN mkdir -p /etc/prometheus
-RUN go mod download
-COPY documentation/examples/prometheus.yml  /etc/prometheus/prometheus.yml
-RUN go build -o prometheus ./cmd/prometheus/main.go
 RUN ln -s /usr/share/prometheus/console_libraries /usr/share/prometheus/consoles/ /etc/prometheus/ && \
-    chown -R nobody:nogroup /etc/prometheus /prometheus
-USER nobody
-EXPOSE     9090 	
+    chown -R nobody:nobody /etc/prometheus /prometheus
+
+USER       nobody
+EXPOSE     9090
 VOLUME     [ "/prometheus" ]
-ENTRYPOINT [ "./prometheus" ]
+ENTRYPOINT [ "/bin/prometheus" ]
 CMD        [ "--config.file=/etc/prometheus/prometheus.yml", \
              "--storage.tsdb.path=/prometheus", \
              "--web.console.libraries=/usr/share/prometheus/console_libraries", \

--- a/ziti.Readme
+++ b/ziti.Readme
@@ -16,7 +16,7 @@ Building an image
 
 run
 
-    docker build -f ziti.Dockerfile . --platform linux/amd64 -t openziti/prometheuz
+    docker build -f ziti.Dockerfile . --platform linux/amd64 -t prometheuz
 
 
 Configuring Ziti - Server Side

--- a/ziti.Readme
+++ b/ziti.Readme
@@ -3,27 +3,20 @@ This is a zitified version of prometheus. This version of prometheus can be conf
 
 Running the executable
 
-The executable expects to be ran from the same directory that the /web directly is located in order to display the prometheus UI. In order to run the executable first clone the 
+The executable expects to be ran from the same directory that the /web directly is located in order to display the prometheus UI.
 
 Building:
-For local development, first run
+For local development, run
 
-make assets
+    make build
 
-this will create the required web assets for displaying metrics using the react app provided by the prometheus project. Next run the following command
-
-go build -o prometheus ./cmd/prometheus/main.go
-
+this will create the prometheus binaries and required web assets for displaying metrics using the react app provided by the prometheus project
 
 Building an image
 
-first run
+run
 
-make assets
-
-and then run
-
-docker build -f ziti.Dockerfile . --platform linux/amd64
+    docker build -f ziti.Dockerfile . --platform linux/amd64 -t openziti/prometheuz
 
 
 Configuring Ziti - Server Side


### PR DESCRIPTION
* use Prometheus build procedure (`make`, `promu`)
* add build stage to dockerifle so only run-time artifacts end up in the published image

`$ docker image ls --filter 'reference=*/prometheu*'`:

    REPOSITORY            TAG       IMAGE ID       CREATED         SIZE
    openziti/prometheuz   latest    6017da676fc1   5 minutes ago   214MB
    prom/prometheus       latest    e528f02c45a6   7 days ago      204MB
